### PR TITLE
feat: Activate Socket Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # JetBrains IDE
 .idea/
 *.iml
+
+variables.env

--- a/README.md
+++ b/README.md
@@ -2,21 +2,34 @@
 [![playwright-version](https://img.shields.io/badge/revChatGPT-0.0.31.5-green.svg)](https://github.com/acheong08/ChatGPT)
 [![license](https://img.shields.io/badge/License-GPL%202.0-brightgreen.svg)](LICENSE)
 
-This is a simple Slackbot that uses the [acheong08/ChatGPT](https://github.com/acheong08/ChatGPT) `revChatGPT` package to respond to messages in Slack. It is designed to be used with the Slack Events API, and it listens for `app_mention` events, which are triggered when a user mentions the bot in a Slack channel.
+This is a simple Slackbot that uses the [acheong08/ChatGPT](https://github.com/acheong08/ChatGPT)
+`revChatGPT` package to respond to messages in Slack. It is designed to be used with the Slack
+Events API, and it listens for `app_mention` events, which are triggered when a user mentions the
+bot in a Slack channel.
 
-When the bot receives a `app_mention` event, it extracts the user's message from the event payload, sends it to the `revChatGPT` package to generate a response, and then sends the response back to the user via Slack.
+When the bot receives a `app_mention` event, it extracts the user's message from the event payload,
+sends it to the `revChatGPT` package to generate a response, and then sends the response back to
+the user via Slack.
 
-The `revChatGPT` package is used to handle authentication and communication with the GPT-3 API, and it is also used to refresh the session with the GPT-3 API on a regular basis. This is done in a separate thread to prevent the session from expiring while the bot is handling requests.
+The `revChatGPT` package is used to handle authentication and communication with the GPT-3 API, and
+it is also used to refresh the session with the GPT-3 API on a regular basis. This is done in a
+separate thread to prevent the session from expiring while the bot is handling requests.
 
 ## Usage
 
-To use the bot, you will need to install the dependencies and set the `CHATGPT_EMAIL` and `CHATGPT_PASSWORD` environment variables with your OpenAI credentials. You also need to set `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN` environment variables after creating the Slack App. You can then run the `app.py` script to start the bot.
+To use the bot, you will need to install the dependencies and set the `CHATGPT_EMAIL` and
+`CHATGPT_PASSWORD` environment variables with your OpenAI credentials. You also need to set
+`SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN` environment variables after creating the Slack App.
+If you keep the config for socket_mode, you'll need to create an App Token (I used the
+ connection:write scope).  You can then run the `app.py` script to start the bot.
 
 ```python
 pip install -r requirements.txt
-export SLACK_SIGNING_SECRET=slack_signing_secret
-export SLACK_BOT_TOKEN=slack_bot_token
-export OPENAI_API_KEY=you_openai_api_key
+export SLACK_APP_TOKEN=xapp-...
+export SLACK_BOT_TOKEN=xoxb-...
+export SLACK_SIGNING_SECRET=(32 hex chars == 256b)
+export OPENAI_API_KEY=(a JWT that fails signature on https://token.dev but parses to show your email in the profile of the payload)
+
 python app.py
 ```
 
@@ -26,19 +39,28 @@ Alternatively, you can use the containerized version by setting the environment 
 docker-compose up -d
 ```
 
-Once the bot is running, you can mention it in a Slack channel to send it a message. For example, you can type `@my-bot hello` to send the message "hello" to the bot. The bot will respond with a generated message based on the GPT-3 model.
+Once the bot is running, you can mention it in a Slack channel to send it a message. For example,
+you can type `@my-bot hello` to send the message "hello" to the bot. The bot will respond with a
+generated message based on the GPT-3 model.
 
 ## ChatGPT Configuration
 
-The `ChatGPTConfig` dictionary at the top of the `app.py` script contains the configuration for the `revChatGPT` package. It specifies the email and password for the OpenAI account that the bot will use to authenticate with the GPT-3 API. These values are read from the `CHATGPT_EMAIL` and `CHATGPT_PASSWORD` environment variables.
+The `ChatGPTConfig` dictionary at the top of the `app.py` script contains the configuration for the
+`revChatGPT` package. It specifies the email and password for the OpenAI account that the bot will
+use to authenticate with the GPT-3 API. These values are read from the `CHATGPT_EMAIL` and
+`CHATGPT_PASSWORD` environment variables.
 
-The `conversation_id` parameter in the `Chatbot` constructor is used to specify the ID of the conversation that the bot should use. If this parameter is not provided, the `revChatGPT` package will generate a new conversation ID for each message that the bot receives.
+The `conversation_id` parameter in the `Chatbot` constructor is used to specify the ID of the
+conversation that the bot should use. If this parameter is not provided, the `revChatGPT` package
+will generate a new conversation ID for each message that the bot receives.
 
 ## Slack Configuration
 
-By default, `app.py` is exposing port 4000 for Slack events. You may change the port number in the end of the script.
+By default, `app.py` is exposing port 4000 for Slack events. You may change the port number in the
+end of the script.
 
-To configure the Slack App, follow [these](https://github.com/slackapi/python-slack-events-api/blob/main/example/README.rst) example instructions from the official SlackApi GitHub account.
+To configure the Slack App, follow [these](https://github.com/slackapi/python-slack-events-api/blob/main/example/README.rst)
+example instructions from the official SlackApi GitHub account.
 
 For this bot, the required Scopes in `OAuth & Permissions` are:
 * app_mentions:read
@@ -51,18 +73,64 @@ For direct message required & config :
 
 In the `Event Subscriptions`, you need to subscribe to the `app_mention` event.
 
+Activating Socket Mode, I requested a Scoped permission with the `connection:write` scope and it
+has been working.
+
+### Slack Configuration by Manifest
+
+```yaml
+_metadata:
+  major_version: 1
+  minor_version: 0
+display_information:
+  name: ChatGPT3SlackBot
+  description: revChatGPT -based Slackbot
+  long_description: This is a simple Slackbot that uses the
+    acheong08/ChatGPT package (https://github.com/acheong08/ChatGPT)
+    `revChatGPT` package to respond to messages in Slack. It is designed to be
+    used with the Slack Events API, and it listens for `app_mention` events,
+    which are triggered when a user mentions the bot in a Slack channel.
+  background_color: "#0000AA"
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+    request_url: http://chatgptslackbot.example.com:4000/slack/events
+  socket_mode_enabled: true
+features:
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+  bot_user:
+    display_name: GPT3
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - chat:write
+      - im:write
+```
+
 ## Limitations
 
-The bot uses a pre-trained GPT-3 model, which means that its responses are limited to the information that is contained in the model. It may not be able to respond accurately to messages that are outside of the scope of the pre-trained model.
+The bot uses a pre-trained GPT-3 model, which means that its responses are limited to the
+information that is contained in the model. It may not be able to respond accurately to messages
+that are outside of the scope of the pre-trained model.
 
-Additionally, the bot is only designed to handle `app_mention` events, so it will not respond to other types of messages. This can be easily extended by adding more event handlers to the `app.py` script.
+Additionally, the bot is only designed to handle `app_mention` events, so it will not respond to
+other types of messages. This can be easily extended by adding more event handlers to the `app.py`
+script.
 
 ## Notes
 
-The `tls-client` python library that is used by the `revChatGPT` package does not currently support ARM architectures. As a result, the bot may not be able to run on devices with ARM processors. This limitation will be addressed in a future update.
+The `tls-client` python library that is used by the `revChatGPT` package does not currently support
+ARM architectures. As a result, the bot may not be able to run on devices with ARM processors. This
+limitation will be addressed in a future update.
 
 ## Disclaimer
 This is a personal project and is not affiliated with OpenAI or Slack in any way.
 
 ## License
-This project is released under the terms of the GPL 2.0 license. For more information, see the [LICENSE](LICENSE) file included in the repository.
+This project is released under the terms of the GPL 2.0 license. For more information, see the
+[LICENSE](LICENSE) file included in the repository.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
 import os
 import re
+import sys
 import time
 from threading import Thread
 
 from revChatGPT.V3 import Chatbot
 from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
 
 ChatGPTConfig = {
     "api_key": os.getenv("OPENAI_API_KEY"),
@@ -13,20 +15,24 @@ ChatGPTConfig = {
 if os.getenv("OPENAI_ENGINE"):
     ChatGPTConfig["engine"] = os.getenv("OPENAI_ENGINE")
 
-app = App()
+app = App(
+    signing_secret=os.getenv("SLACK_SIGNING_SECRET"),
+    token=os.getenv("SLACK_BOT_TOKEN"),
+)
 chatbot = Chatbot(**ChatGPTConfig)
 
 
 @app.event("app_mention")
 def event_test(event, say):
-    prompt = re.sub('\\s<@[^, ]*|^<@[^, ]*', '', event['text'])
+    prompt = re.sub("\\s<@[^, ]*|^<@[^, ]*", "", event["text"])
     try:
         response = chatbot.ask(prompt)
-        user = event['user']
+        user = event["user"]
         send = f"<@{user}> {response}"
     except Exception as e:
         print(e)
-        send = "We're experiencing exceptionally high demand. Please, try again."
+        print("{} (a {})".format(e, type(e)), file=sys.stderr)
+        send = "(Mention) Exception was logged on service process, usually due to high demand (please retry)."
 
     # Get the `ts` value of the original message
     original_message_ts = event["ts"]
@@ -34,19 +40,22 @@ def event_test(event, say):
     # Use the `app.event` method to send a reply to the message thread
     say(send, thread_ts=original_message_ts)
 
+
 @app.event("message")
 def event_test(event, say):
-    prompt = re.sub('\\s<@[^, ]*|^<@[^, ]*', '', event['text'])
+    prompt = re.sub("\\s<@[^, ]*|^<@[^, ]*", "", event["text"])
     try:
         response = chatbot.ask(prompt)
-        user = event['user']
+        user = event["user"]
         send = response
     except Exception as e:
         print(e)
-        send = "We're experiencing exceptionally high demand. Please, try again."
+        print("{} (a {})".format(e, type(e)), file=sys.stderr)
+        send = "(Message) Exception was logged on service process, usually due to high demand (please retry)."
 
     # reply message to new message
     say(send)
+
 
 def chatgpt_refresh():
     while True:
@@ -54,6 +63,11 @@ def chatgpt_refresh():
 
 
 if __name__ == "__main__":
-    thread = Thread(target=chatgpt_refresh)
-    thread.start()
-    app.start(4000)  # POST http://localhost:4000/slack/events
+    # Give a Slack App Token to trigger SocketMode
+    if os.getenv("SLACK_APP_TOKEN"):
+        handler = SocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+        handler.start()
+    else:
+        thread = Thread(target=chatgpt_refresh)
+        thread.start()
+        app.start(os.getenv("PORT"))  # POST http://localhost:4000/slack/events


### PR DESCRIPTION
Added documentation: Manifest for creating Slackbot -- I personally find it better to see a concise chunk of code rather than a "click here, look for the red box, click there" (especially since Slack's UI seems to change often, rendering past play-by-play directions ambiguous at best).

Blacken-formatted the app.py

Activated Socket Mode as my implementation is behind an ISP who "protects" me by limiting inbound service.  Thanks-No-Thanks, guys :) 

Works to the point of accepting traffic and failing to activate ChatGPT on a stake token.

